### PR TITLE
Adding Query Params to Fine Tune API Results

### DIFF
--- a/routes/en.js
+++ b/routes/en.js
@@ -20,9 +20,11 @@ router.get("/", function (req, res) {
   res.header("Strict-Transport-Security", "max-age=63072000");
   res.setHeader("Content-Type", "application/json");
 
+  const partOfSpeech = req.query.type;
+
   axios({
     method: "GET",
-    url: "https://randomword.com/",
+    url: partOfSpeech ? `https://randomword.com/${partOfSpeech}` : `https://randomword.com`,
     headers: {
       "User-Agent": rua,
     },


### PR DESCRIPTION
I am totally open to whatever implementation of this. But I believe your public api can be extended to provide users with the option of selecting what parts of speech they want as results based on the endpoints available on randomword.com. 
So now users can select whether or not they want an adjective, a noun, a verb and so forth:
_https://random-words-api.vercel.app/word?type=adjective_
_https://random-words-api.vercel.app/word?type=noun_
_https://random-words-api.vercel.app/word?type=verb_

I have tested this with all endpoints on randomword.com. Even ?type=1-word-quotes work as intended. 
I believe this to be a useful feature for anyone looking for a free random word generator. Having the option to select parts of speech to create interesting strings (that are not just _noun noun noun_ seems to be a common use case, so I see this is a big plus. The only addition I could see is of course a doc update, and possible error handling if the user enters a ?type that is not available through randomword.com. Just wanted to propose this. And thanks for such a lightweight and handy tool.