### PR TITLE
Extending API with URL Params for Parts of Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@
 
 - PWA Demo - [Check Here](https://words.sanweb.info/)
 
+## 🎛 Route Options
+
+- Base URL: `https://random-words-api.vercel.app/word`
+```html
+- /noun
+- /sentence
+- /question
+- /adjective
+- /idiom
+- /verb
+- /letter
+- /paragraph
+- /vocabulary
+- /1-word-quotes
+- /2-word-quotes
+- /3-word-quotes
+- /affirmation
+```
+
 ## 🌐 Sample API Response
 
 ```json

--- a/routes/en.js
+++ b/routes/en.js
@@ -24,7 +24,73 @@ router.get("/", function (req, res) {
 
   axios({
     method: "GET",
-    url: partOfSpeech ? `https://randomword.com/${partOfSpeech}` : `https://randomword.com`,
+    url: 'https://randomword.com',
+    headers: {
+      "User-Agent": rua,
+    },
+  })
+    .then(function (response) {
+      $ = cheerio.load(response.data);
+      if (wordOfDay.length > 0) {
+        wordOfDay = [];
+      }
+
+      var post = $(".section #shared_section");
+      var word = post
+        .find("#random_word")
+        .eq(0)
+        .text()
+        .replace("\r\n\t\t\t\t\t", "")
+        .replace("\r\n\t\t\t\t", "")
+        .replace("\n\t\t\t\t\t", "")
+        .replace("\n\t\t\t\t", "");
+      var definition = post
+        .find("#random_word_definition")
+        .eq(0)
+        .text()
+        .replace("\n", "");
+      var pronounceword = pronounce(word).replace(",", "");
+
+      wordOfDay.push({
+        word: decodeURI(word.charAt(0).toUpperCase() + word.slice(1)),
+        definition: decodeURI(
+          definition.charAt(0).toUpperCase() + definition.slice(1)
+        ),
+        pronunciation: decodeURI(
+          pronounceword.charAt(0).toUpperCase() + pronounceword.slice(1)
+        ),
+      });
+      res.send(JSON.stringify(wordOfDay, null, 2));
+    })
+    .catch(function (error) {
+      if (!error.response) {
+        console.log("API URL is Missing");
+        res.json("API URL is Missing");
+      } else {
+        console.log("Something Went Wrong - Enter the Correct API URL");
+        res.json("Something Went Wrong - Enter the Correct API URL");
+      }
+    });
+});
+
+router.get("/:pos", function (req, res) {
+
+  const partOfSpeech = req.params.pos;
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Access-Control-Allow-Headers,Content-Type,Access-Control-Allow-Methods, Authorization, X-Requested-With"
+  );
+  res.header("Access-Control-Allow-Methods", "GET");
+  res.header("X-Frame-Options", "DENY");
+  res.header("X-XSS-Protection", "1; mode=block");
+  res.header("X-Content-Type-Options", "nosniff");
+  res.header("Strict-Transport-Security", "max-age=63072000");
+  res.setHeader("Content-Type", "application/json");
+
+  axios({
+    method: "GET",
+    url: `https://randomword.com/${partOfSpeech}`,
     headers: {
       "User-Agent": rua,
     },

--- a/routes/en.js
+++ b/routes/en.js
@@ -6,6 +6,7 @@ const { pronounce } = require("node-pronounce");
 const randomUseragent = require("random-useragent");
 const rua = randomUseragent.getRandom();
 var wordOfDay = [];
+const baseUrl = 'https://randomword.com';
 
 router.get("/", function (req, res) {
   res.header("Access-Control-Allow-Origin", "*");
@@ -20,11 +21,9 @@ router.get("/", function (req, res) {
   res.header("Strict-Transport-Security", "max-age=63072000");
   res.setHeader("Content-Type", "application/json");
 
-  const partOfSpeech = req.query.type;
-
   axios({
     method: "GET",
-    url: 'https://randomword.com',
+    url: baseUrl,
     headers: {
       "User-Agent": rua,
     },
@@ -74,8 +73,6 @@ router.get("/", function (req, res) {
 });
 
 router.get("/:pos", function (req, res) {
-
-  const partOfSpeech = req.params.pos;
   res.header("Access-Control-Allow-Origin", "*");
   res.header(
     "Access-Control-Allow-Headers",
@@ -88,9 +85,11 @@ router.get("/:pos", function (req, res) {
   res.header("Strict-Transport-Security", "max-age=63072000");
   res.setHeader("Content-Type", "application/json");
 
+  const partOfSpeech = req.params.pos;
+
   axios({
     method: "GET",
-    url: `https://randomword.com/${partOfSpeech}`,
+    url: `${baseUrl}/${partOfSpeech}`,
     headers: {
       "User-Agent": rua,
     },


### PR DESCRIPTION
I swapped out my last PR with query params for URL params. In addition to the new route in en.js, I also updated the readme with some info about the available endpoint options. You may want to display that differently, but I figured I would add it in so you didn't have to go through all of randomword.com and copy those route parameters!

I tested all possible route options, and they are working too. 🤟

Let me know if you think it needs anything else or some kind of cleaning up - I'm happy to knock that out. 🙏
